### PR TITLE
[Feat] file list and download api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,14 @@ app.get('/api/files', async (_req, res) => {
 
 app.get('/files/:name', (req, res) => {
     const p = path.join(uploadDir, req.params.name);
-    if (!fs.existsSync(p)) return res.status(404).end('not found');
-    res.download(p);
+    if (!fs.existsSync(p)) {
+        return res.status(404).json({
+            error: 'file_not_found',
+            message: 'File does not exist.'
+        })
+    } else {
+        res.download(p);
+    }
 });
 
 app.use((err: any, req:express.Request, res:express.Response, next:express.NextFunction) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,12 @@ app.get('/api/files', async (_req, res) => {
     }
 });
 
+app.get('/files/:name', (req, res) => {
+    const p = path.join(uploadDir, req.params.name);
+    if (!fs.existsSync(p)) return res.status(404).end('not found');
+    res.download(p);
+});
+
 app.use((err: any, req:express.Request, res:express.Response, next:express.NextFunction) => {
     console.error(err);
     if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE'){

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,21 @@ app.post('/api/upload', upload.single('file'), (req, res) => {
     res.json({  filename: req.file.filename, size: req.file.size  });
 });
 
+app.get('/api/files', async (_req, res) => {
+    try {
+        const entries = await fs.promises.readdir(uploadDir);
+        const stats = await Promise.all(entries.map(async (name) => {
+            const p = path.join(uploadDir, name);
+            const st = await fs.promises.stat(p);
+            if (!st.isFile()) return null;
+            return { name, size: st.size, mtime: st.mtime };
+        }));
+        res.json(stats.filter(Boolean));
+    } catch (e) {
+        res.status(500).json({  error: 'list_failed'  });
+    }
+});
+
 app.use((err: any, req:express.Request, res:express.Response, next:express.NextFunction) => {
     console.error(err);
     if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE'){


### PR DESCRIPTION
## Related Issue
- closes #12

## Description
- 파일 리스트, 파일 다운로드 api 구현

## Details
- `/api/files` 업로드 파일 목록 JSON 형태로 반환
- `/files/:name` 지정한 파일 다운로드
- 파일이 존재하지 않을 경우 404 에러 반환

##  References
-