### PR TITLE
Refactor/separate api routes into feature-based module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,14 @@ import fs from 'fs';
 import multer from 'multer';
 import path from 'path';
 
+import files from './routes/api/files'
+
 const uploadDir = path.join(__dirname, '..', 'uploads');
 fs.mkdirSync(uploadDir, { recursive: true });
 
 const app = express();
 app.use(express.json());
+app.use('/api/files', files);
 
 app.get('/health', (_req, res) => {
     res.json({  ok: true, ts: new Date().toISOString()  });
@@ -35,33 +38,6 @@ const upload = multer({
 app.post('/api/upload', upload.single('file'), (req, res) => {
     if (!req.file) return res.status(400).json({ error: 'no_file' });
     res.json({  filename: req.file.filename, size: req.file.size  });
-});
-
-app.get('/api/files', async (_req, res) => {
-    try {
-        const entries = await fs.promises.readdir(uploadDir);
-        const stats = await Promise.all(entries.map(async (name) => {
-            const p = path.join(uploadDir, name);
-            const st = await fs.promises.stat(p);
-            if (!st.isFile()) return null;
-            return { name, size: st.size, mtime: st.mtime };
-        }));
-        res.json(stats.filter(Boolean));
-    } catch (e) {
-        res.status(500).json({  error: 'list_failed'  });
-    }
-});
-
-app.get('/files/:name', (req, res) => {
-    const p = path.join(uploadDir, req.params.name);
-    if (!fs.existsSync(p)) {
-        return res.status(404).json({
-            error: 'file_not_found',
-            message: 'File does not exist.'
-        })
-    } else {
-        res.download(p);
-    }
 });
 
 app.use((err: any, req:express.Request, res:express.Response, next:express.NextFunction) => {

--- a/src/routes/api/files.ts
+++ b/src/routes/api/files.ts
@@ -1,0 +1,34 @@
+import { Router } from "express";
+import fs from "fs";
+import path from "path";
+
+const r = Router();
+const uploadDir = path.join(__dirname, '..', '..', '..', 'uploads');
+
+r.get('/', async (_req, res) => {
+    try {
+        const entries = await fs.promises.readdir(uploadDir);
+        const stats = await Promise.all(entries.map(async (name) => {
+            const p = path.join(uploadDir, name);
+            const st = await fs.promises.stat(p);
+            if (!st.isFile) return null;
+            return {  name, size: st.size, mtime: st.mtime };
+        }));
+        res.json(stats.filter(Boolean));
+    } catch (e){
+        res.status(500).json({  error: 'list_failed'  });
+    }
+});
+r.get('/:name', (req, res) => {
+    const p = path.join(uploadDir, req.params.name);
+    if (!fs.existsSync(p)){
+        return res.status(404).json({
+            error: 'file_not_found',
+            message: 'File does not exist.'
+        });
+    } else {
+        res.download(p);
+    }
+});
+
+export default r;


### PR DESCRIPTION
## Related Issue
- closes #14 

## Description
- API 경로를 별도 파일로 분리 (기능별)

## Details
- `files` API 별도 파일 분리 
    - `/src/index.ts` → `/src/routes/api/files.ts`

##  References
- N/A