### PR TITLE
fix(api): add error handling for files api #15

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,10 @@ app.post('/api/upload', upload.single('file'), (req, res) => {
 });
 
 app.use((err: any, req:express.Request, res:express.Response, next:express.NextFunction) => {
-    console.error(err);
+    console.error('[ERROR]', err);
+    if (res.headersSent){
+        return next(err);
+    }
     if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE'){
         return res.status(400).json({
             error: 'file_too_large',
@@ -54,7 +57,6 @@ app.use((err: any, req:express.Request, res:express.Response, next:express.NextF
             message: 'A file with that name already exists.'
         })
     }
-    
     res.status(500).json({
         error: 'internal_server_error',
         message: 'An unexpected error occurred.'

--- a/src/routes/api/files.ts
+++ b/src/routes/api/files.ts
@@ -1,11 +1,12 @@
 import { Router } from "express";
 import fs from "fs";
 import path from "path";
+import { nextTick } from "process";
 
 const r = Router();
 const uploadDir = path.join(__dirname, '..', '..', '..', 'uploads');
 
-r.get('/', async (_req, res) => {
+r.get('/', async (_req, res, next) => {
     try {
         const entries = await fs.promises.readdir(uploadDir);
         const stats = await Promise.all(entries.map(async (name) => {
@@ -16,19 +17,23 @@ r.get('/', async (_req, res) => {
         }));
         res.json(stats.filter(Boolean));
     } catch (e){
-        res.status(500).json({  error: 'list_failed'  });
+       next(e); 
     }
 });
-r.get('/:name', (req, res) => {
+r.get('/:name', (req, res, next) => {
     const p = path.join(uploadDir, req.params.name);
     if (!fs.existsSync(p)){
         return res.status(404).json({
             error: 'file_not_found',
             message: 'File does not exist.'
         });
-    } else {
-        res.download(p);
     }
+    res.download(p, (err) => {
+        if (err){
+            console.error(`Download failed for ${p} after existence check: `, err);
+            next(err);
+        }
+    });
 });
 
 export default r;


### PR DESCRIPTION
## Related Issue
- closes #15

## Description
- `files` api에 에러 핸들링 추가

## Details
- N/A

##  References
- N/A